### PR TITLE
Added MQTT support

### DIFF
--- a/htdocs/functions.php
+++ b/htdocs/functions.php
@@ -1,6 +1,6 @@
 <?php
 
-function interpret_data($postdata, $ignore_registered_users=true)
+function interpret_data($postdata, $ignore_registered_users=false)
 {
 	$header = substr($postdata, 0, 46);
 	$buffer = substr($postdata, 46);
@@ -19,7 +19,7 @@ function interpret_data($postdata, $ignore_registered_users=true)
 	$ret['battery'] = unpack("V", substr($header, 4, 4))[1];
 	$ret['protocol'] = unpack("V", substr($header, 0, 4))[1];
 	$ret['firmware'] = unpack("V", substr($header, 30, 4))[1];
-	$ret['mac'] = dechex(unpack("C", substr($header, 8, 1))[1]) . ":" . dechex(unpack("C", substr($header, 9, 1))[1]) . ":" . dechex(unpack("C", substr($header, 10, 1))[1]) . ":" . dechex(unpack("C", substr($header, 11, 1))[1]) . ":" . dechex(unpack("C", substr($header, 12, 1))[1]);
+	$ret['mac'] = sprintf('%02s', dechex(unpack("C", substr($header, 8, 1))[1])) . ":" . sprintf('%02s', dechex(unpack("C", substr($header, 9, 1))[1])) . ":" . sprintf('%02s', dechex(unpack("C", substr($header, 10, 1))[1])) . ":" . sprintf('%02s', dechex(unpack("C", substr($header, 11, 1))[1])) . ":" . sprintf('%02s', dechex(unpack("C", substr($header, 12, 1))[1]));
 	$ret['readings'] = array();
 
 	foreach($itemstrings as $chunk)

--- a/htdocs/mqtt_send.php
+++ b/htdocs/mqtt_send.php
@@ -1,0 +1,41 @@
+#!/usr/bin/php -q
+<?php
+
+include_once("functions.php");
+
+define('MQTT_BROKER', '127.0.0.1');
+define('MQTT_PORT', 1883);
+define('MQTT_CLIENT_ID', "pubclient_" + getmypid());
+define('MQTT_STATE_TOPIC', "FitBit/Aria/State");
+define('MQTT_SAMPLES_TOPIC', "FitBit/Aria");
+
+if(count($argv) < 2)
+{
+	error_log("Call with a request_data file as an argument.");
+	exit(1);
+}
+
+if (extension_loaded('mosquitto'))
+{
+	$client = new Mosquitto\Client(MQTT_CLIENT_ID);
+	$client->connect(MQTT_BROKER, MQTT_PORT, 60);
+	$postdata = file_get_contents($argv[1]);
+	$ret = interpret_data($postdata);
+	$state = array();
+	$state['battery'] = $ret['battery'];
+	$state['protocol'] = $ret['protocol'];
+	$state['firmware'] = $ret['firmware'];
+	$state['mac'] = $ret['mac'];
+	$message = json_encode($state);
+	$client->publish(MQTT_STATE_TOPIC, $message, 0, false);
+	$client->loop();
+	foreach($ret['readings'] as $item)
+	{
+		$message = json_encode($item);
+		$client->publish(MQTT_SAMPLES_TOPIC, $message, 0, false);
+		$client->loop();
+	}
+}else
+{
+	error_log("Mosquitto extension not loaded!");
+}

--- a/readme.md
+++ b/readme.md
@@ -178,3 +178,17 @@ into a JSON object which can be read into pretty much anything. See the
 'Privacy' section above if you expected to see more data in this file.
 
 
+Configuring MQTT Support
+------------------------
+
+MQTT support can be enabled by adding the mosquitto extension to PHP.
+To install the extension, see https://github.com/mgdm/Mosquitto-PHP 
+
+Once the extension is available, adjust the constants MQTT_BROKER 
+(hostname or IP address of the MQTT broker, MQTT_PORT (port of the
+MQTT broker), MQTT_STATE_TOPIC (MQTT topic where state information 
+like firmware version and battery level will be posted) and 
+MQTT_SAMPLES_TOPIC (MQTT topic where weight samples will be posted)
+to the values for your broker if needed.
+
+Currently username/password authentication is not implemented.


### PR DESCRIPTION
Hi,

I wanted to consume the Aria data in my home automation system for graphing and battery monitoring, so I added support for pushing the data from the scale to other systems via MQTT. The MQTT support is built based on the Mosquitto MQTT client library and Mosquitto-PHP (https://github.com/mgdm/Mosquitto-PHP). The way I implemented it ensures that if the Mosquitto PHP extension is not loaded, it will not cause any errors and just jump over the code, so it should be transparent for existing users of aria-spoof.

Thanks for your work and I hope you consider integrating these changes.

Best regards,
Reiner 